### PR TITLE
Remove Task.Run wrapper and add VSTHRD100 analyzer

### DIFF
--- a/Guidance.md
+++ b/Guidance.md
@@ -80,6 +80,11 @@ public class MyController : Controller
 
 :bulb: The [VSTHRD100](https://github.com/Microsoft/vs-threading/blob/master/doc/analyzers/VSTHRD100.md) analyzer will call out use of `async void` and offer a code fix to correct them.
 
+:bulb: The [VSTHRD101](https://github.com/Microsoft/vs-threading/blob/master/doc/analyzers/VSTHRD101.md)
+analyzer will find much harder to detect cases where an async delegate is supplied to a method
+that only accepts `Action`. The C# compiler will allow this by implicitly generating an `async void` method.
+This analyzer will prevent this from going unnoticed.
+
 ## Avoid using Task.Run for long running work that blocks the thread
 
 `Task.Run` will queue a work item to thread pool. The assumption is that that work will finish quickly (or quickly enough to allow reusing that thread within some rasonable timeframe). Stealing a thread pool thread for long running work is bad since it takes that thread away from other work that could be done (timer callbacks, task continuations etc). Instead, spawn a new thread manually to do long running blocking work.

--- a/Guidance.md
+++ b/Guidance.md
@@ -80,11 +80,6 @@ public class MyController : Controller
 
 :bulb: The [VSTHRD100](https://github.com/Microsoft/vs-threading/blob/master/doc/analyzers/VSTHRD100.md) analyzer will call out use of `async void` and offer a code fix to correct them.
 
-:bulb: The [VSTHRD101](https://github.com/Microsoft/vs-threading/blob/master/doc/analyzers/VSTHRD101.md)
-analyzer will find much harder to detect cases where an async delegate is supplied to a method
-that only accepts `Action`. The C# compiler will allow this by implicitly generating an `async void` method.
-This analyzer will prevent this from going unnoticed.
-
 ## Avoid using Task.Run for long running work that blocks the thread
 
 `Task.Run` will queue a work item to thread pool. The assumption is that that work will finish quickly (or quickly enough to allow reusing that thread within some rasonable timeframe). Stealing a thread pool thread for long running work is bad since it takes that thread away from other work that could be done (timer callbacks, task continuations etc). Instead, spawn a new thread manually to do long running blocking work.
@@ -621,6 +616,9 @@ public class BackgroundQueue
     public static void FireAndForget(Func<Task> action) { }
 }
 ```
+
+:bulb: The [VSTHRD101](https://github.com/Microsoft/vs-threading/blob/master/doc/analyzers/VSTHRD101.md)
+analyzer will call out when async anonymous delegates and lambdas are misinterpreted as `Action`. The C# compiler will allow this by implicitly generating an `async void` method, but this analyzer will prevent this from going unnoticed.
 
 ## ConcurrentDictionary.GetOrAdd
 

--- a/Guidance.md
+++ b/Guidance.md
@@ -66,7 +66,7 @@ public class MyController : Controller
     [HttpPost("/start")]
     public IActionResult Post()
     {
-        Task.Run(BackgroundOperationAsync);
+        BackgroundOperationAsync();
         return Accepted();
     }
     
@@ -77,6 +77,8 @@ public class MyController : Controller
     }
 }
 ```
+
+:bulb: The [VSTHRD100](https://github.com/Microsoft/vs-threading/blob/master/doc/analyzers/VSTHRD100.md) analyzer will call out use of `async void` and offer a code fix to correct them.
 
 ## Avoid using Task.Run for long running work that blocks the thread
 


### PR DESCRIPTION
The `Task.Run` added in the "GOOD" example was not equivalent to old behavior and is not necessary for the principle being documented.