### PR TITLE
Remove warning about mixing up RunContinuationsAsynchronously

### DIFF
--- a/Guidance.md
+++ b/Guidance.md
@@ -273,8 +273,6 @@ public async Task<int> DoSomethingAsync()
 }
 ```
 
-:warning: **NOTE: There are 2 enums that look alike. [TaskCreationOptions.RunContinuationsAsynchronously](https://docs.microsoft.com/en-us/dotnet/api/system.threading.tasks.taskcreationoptions?view=netcore-2.0#System_Threading_Tasks_TaskCreationOptions_RunContinuationsAsynchronously) and [TaskContinuationOptions.RunContinuationsAsynchronously](https://docs.microsoft.com/en-us/dotnet/api/system.threading.tasks.taskcontinuationoptions?view=netcore-2.0). Be careful not to confuse their usage.** 
-
 ## Always dispose CancellationTokenSource(s) used for timeouts
 
 CancellationTokenSources that are used for timeouts (are created with timers or uses the CancelAfter method), can put pressure on the timer queue if not disposed. 


### PR DESCRIPTION
These can't be mixed up without explicit casting. So it isn't worth calling out.
Even if the user did find a way to mix these up, it *literally* wouldn't matter because semantically they are equivalent, and they are literally equivalent as well (both have a 0x40 value).