### PR TITLE
Await the WriteAsync calls

### DIFF
--- a/Guidance.md
+++ b/Guidance.md
@@ -448,7 +448,7 @@ app.Run(async context =>
     // The implicit Dispose call will synchronously write to the response body
     using (var streamWriter = new StreamWriter(context.Response.Body))
     {
-        streamWriter.WriteAsync("Hello World");
+        await streamWriter.WriteAsync("Hello World");
     }
 });
 ```
@@ -460,8 +460,8 @@ app.Run(async context =>
 {
     using (var streamWriter = new StreamWriter(context.Response.Body))
     {
-        streamWriter.WriteAsync("Hello World");
-        
+        await streamWriter.WriteAsync("Hello World");
+
         // Force an asynchronous flush
         await streamWriter.FlushAsync();
     }


### PR DESCRIPTION
While this may not be strictly necessary in the BAD or GOOD examples,
omitting the await may be misinterpreted as a required condition for the BAD case.
To avoid people rationalizing leaving their code alone by thinking "well, I always await the WriteAsync call, so I'm good",
I'm adding the await call to the sample to show that even that doesn't mitigate the problem.