### PR TITLE
Remove async/await non-benefits from the benefits list

### DIFF
--- a/Guidance.md
+++ b/Guidance.md
@@ -473,8 +473,6 @@ app.Run(async context =>
 There are benefits to using the async/await keyword instead of directly returning the Task:
 - Asynchronous and synchronous exceptions are normalized to always be asynchronous.
 - The code is easier to modify (consider adding a using for example).
-- The compiler generated code is constantly being improved.
-- The performance of async/await is constantly being improved.
 - Diagnostics of asynchronous methods are easier (debugging hangs etc).
 
 ❌ **BAD** This example directly returns the `Task` to the caller.


### PR DESCRIPTION
These aren't benefits -- they're rationalizations that the *negatives* of using async/await may be reduced in the future. Returning a bare `Task` makes any performance and compiler improvements in the future irrelevant because you've already optimized the time to 0.

I'm not arguing against the entire section -- I just think these two points are detracting and should be removed from the benefits list.