### PR TITLE
Removed note about expensive context switching

### DIFF
--- a/AsyncGuidance.md
+++ b/AsyncGuidance.md
@@ -140,7 +140,7 @@ public class MyLibrary
 
 Long running work in this context refers to a thread that's running for the lifetime of the application doing background work (like processing queue items, or sleeping and waking up to process some data). `Task.Run` will queue a work item to thread pool. The assumption is that that work will finish quickly (or quickly enough to allow reusing that thread within some reasonable timeframe). Stealing a thread pool thread for long running work is bad since it takes that thread away from other work that could be done (timer callbacks, task continuations etc). Instead, spawn a new thread manually to do long running blocking work.
 
-:bulb: **NOTE: The thread pool grows if you block threads but it's bad practice to do so. An increased number of threads in the thread pool results in lots of context switching that can hurt the overall performance of your application.**
+:bulb: **NOTE: The thread pool grows if you block threads but it's bad practice to do so.**
 
 :bulb: **NOTE:`Task.Factory.StartNew` has an option `TaskCreationOptions.LongRunning` that under the covers creates a new thread and returns a Task that represents the execution. Using this properly requires several non-obvious parameters to be passed in to get the right behavior on all platforms.**
 


### PR DESCRIPTION
Context switching applies to all threads, not only those in managed thread pool. So if i create one manually (as advised in this section) i increase the overall cost of context switching regardless.