### PR TITLE
typo in code example fix: "origonal" -> "original"

### DIFF
--- a/AsyncGuidance.md
+++ b/AsyncGuidance.md
@@ -251,7 +251,7 @@ public string DoOperationBlocking2()
 public string DoOperationBlocking3()
 {
     // Bad - Blocking the thread that enters, and blocking the theadpool thread inside.
-    // In the case of an exception, this method will throw an AggregateException containing another AggregateException, containing the origonal exception.
+    // In the case of an exception, this method will throw an AggregateException containing another AggregateException, containing the original exception.
     return Task.Run(() => DoAsyncOperation().Result).Result;
 }
 


### PR DESCRIPTION
Hi. 

I fixed a typo ("origonal" -> "original") in the async guidance code example.

Thanks,
V.