### PR TITLE
Clarify `DoOperationBlocking2` exception handling

### DIFF
--- a/AsyncGuidance.md
+++ b/AsyncGuidance.md
@@ -245,6 +245,7 @@ public string DoOperationBlocking2()
 {
     // Bad - Blocking the thread that enters.
     // DoAsyncOperation will be scheduled on the default task scheduler, and remove the risk of deadlocking.
+    // In the case of an exception, this method will throw the exception without wrapping it in an AggregateException.
     return Task.Run(() => DoAsyncOperation()).GetAwaiter().GetResult();
 }
 


### PR DESCRIPTION
This PR documents that `DoOperationBlocking2` does throw the original exception without wrapping it.  (Since this was omitted, it's not clear if the exception would be swallowed)