### PR TITLE
Update AsyncGuidance.md for ConfigureAwait

### DIFF
--- a/AsyncGuidance.md
+++ b/AsyncGuidance.md
@@ -667,7 +667,7 @@ public class Pinger
 
     private async Task DoAsyncPing()
     {
-        await _client.GetAsync("http://mybackend/api/ping");
+        await _client.GetAsync("http://mybackend/api/ping").ConfigureAwait(false);
     }
 }
 ```


### PR DESCRIPTION
`.ConfigureAwait(false)` is used to avoid forcing the callback to be invoked on the original context or scheduler. 
Reference: [https://devblogs.microsoft.com/dotnet/configureawait-faq/](https://devblogs.microsoft.com/dotnet/configureawait-faq/)