### PR TITLE
Clarify sentence

### DIFF
--- a/AsyncGuidance.md
+++ b/AsyncGuidance.md
@@ -461,7 +461,7 @@ One of the coding patterns that appears when doing asynchronous programming is c
 
 ### Using CancellationTokens
 
-❌ **BAD** This example uses `Task.Delay(-1, token)` to create a `Task` that completes when the `CancellationToken` fires, but if it doesn't fire, there's no way to dispose of the `CancellationTokenRegistration`. This can lead to a memory leak.
+❌ **BAD** This example uses `Task.Delay(-1, token)` to create a `Task` that completes when the `CancellationToken` fires, but if it doesn't fire, there's no way to dispose of the `CancellationTokenRegistration` created inside of `Task.Delay`. This can lead to a memory leak.
 
 ```C#
 public static async Task<T> WithCancellation<T>(this Task<T> task, CancellationToken cancellationToken)


### PR DESCRIPTION
Also I think that _there's no way to dispose of the CancellationTokenRegistration_ part is not related to the example but more to the design of `Task.Delay` API itself.